### PR TITLE
Fix pong messages to follow the graphql websocket protocol.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ all APIs might be changed.
 
 ## Unreleased
 
+### Bug Fixes
+
+- Fixed ping responses not following the graphql-transport-ws protocol
+  ([#116](https://github.com/obmarg/graphql-ws-client/pull/116))
+
+### Contributors
+
+Thanks to the people who contributed to this release:
+
+- @vorporeal
+
 ## v0.10.1 - 2024-06-08
 
 ### Bug Fixes

--- a/src/next/actor.rs
+++ b/src/next/actor.rs
@@ -149,7 +149,7 @@ impl ConnectionActor {
                 None
             }
             Event::ConnectionAck { .. } => Some(Message::close(Reason::UnexpectedAck)),
-            Event::Ping { .. } => Some(Message::Pong),
+            Event::Ping { .. } => Some(Message::graphql_pong()),
             Event::Pong { .. } => None,
         }
     }


### PR DESCRIPTION
## Description

The graphql websocket protocol uses messages with the `text` opcode and payload `{"type": "ping"}`/`{"type": "pong"}` instead of using the `ping` and `pong` opcodes.

See: https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#ping

## Testing

Tested locally that this fixes issues observed where `warp-server-rtc` would close the connection after a ping/pong cycle.